### PR TITLE
Refactor LED warnings to use python-standard warnings module

### DIFF
--- a/xbox360controller/controller.py
+++ b/xbox360controller/controller.py
@@ -10,6 +10,7 @@ import select
 import struct
 import sys
 import time
+import warnings
 from array import array
 from collections import namedtuple
 from fcntl import ioctl
@@ -20,7 +21,7 @@ from xbox360controller.linux.input import *
 from xbox360controller.linux.input_event_codes import *
 from xbox360controller.linux.joystick import *
 
-LED_PERMISSION_WARNING = """Warning: Permission to the LED sysfs file was denied.
+LED_PERMISSION_WARNING = """Permission to the LED sysfs file was denied.
 You may run this script as user root or try creating a udev rule containing:
 
   SUBSYSTEM=="leds", RUN+="/bin/chmod 666 /sys/class/leds/%k/brightness"
@@ -28,7 +29,7 @@ You may run this script as user root or try creating a udev rule containing:
 E.g. in a file /etc/udev/rules.d/xpad.rules
 """
 
-LED_SUPPORT_WARNING = """Warning: Setting the LED status is not supported for
+LED_SUPPORT_WARNING = """Setting the LED status is not supported for
 this gamepad or its driver.
 """
 
@@ -170,18 +171,15 @@ class Xbox360Controller:
 
         self._event_file = open(self._get_event_file(), "wb")
 
-        def _led_error(msg):
-            sys.stderr.write(msg)
-            sys.stderr.flush()
-            time.sleep(0.1)
-            self._led_file = None
-
+        self._led_file = None
         try:
             self._led_file = open(self._get_led_file(), "w")
         except PermissionError:
-            _led_error(LED_PERMISSION_WARNING)
+            warnings.warn(
+                LED_PERMISSION_WARNING, UserWarning)
         except FileNotFoundError:
-            _led_error(LED_SUPPORT_WARNING)
+            warnings.warn(
+                LED_SUPPORT_WARNING, UserWarning)
 
         if raw_mode:
             self.axes = self._get_axes()

--- a/xbox360controller/controller.py
+++ b/xbox360controller/controller.py
@@ -175,11 +175,9 @@ class Xbox360Controller:
         try:
             self._led_file = open(self._get_led_file(), "w")
         except PermissionError:
-            warnings.warn(
-                LED_PERMISSION_WARNING, UserWarning)
+            warnings.warn(LED_PERMISSION_WARNING, UserWarning)
         except FileNotFoundError:
-            warnings.warn(
-                LED_SUPPORT_WARNING, UserWarning)
+            warnings.warn(LED_SUPPORT_WARNING, UserWarning)
 
         if raw_mode:
             self.axes = self._get_axes()


### PR DESCRIPTION
Howdy,
Used your library to set up a controller for a robotics application where I needed a quick and dirty interface - functionality works as advertised, and I appreciate the pypi-available install.

My controller doesn't have LEDs, but I found that the warning messages saying so were not compatible with the [python `warnings` standard library module](https://docs.python.org/3/library/warnings.html), and as such I could not filter them out of my user's text logs. This pull request should rectify that.

I haver verified, through the example below, that the filter below successfully halts both warnings from printing:
```
import warnings
from xbox360controller import Xbox360Controller
warnings.filterwarnings('ignore', category=UserWarning, message=".*LED")
c = Xbox360Controller()
```

I can codify this in a unittest if you want.