### PR TITLE
Fix renamed Python stdlib method

### DIFF
--- a/xbox360controller/controller.py
+++ b/xbox360controller/controller.py
@@ -422,13 +422,7 @@ class Xbox360Controller:
     def name(self):
         buf = array("B", [0] * 64)
         ioctl(self._dev_file, JSIOCGNAME(len(buf)), buf)
-        try:
-            # Python >=3.2
-            buf_bytes = buf.tobytes()
-        except AttributeError:
-            # Python <3.2
-            buf_bytes = buf.tostring()
-        return buf_bytes.decode()
+        return buf.tobytes().decode()
 
     def info(self):
         print("{0} at index {1}".format(self.name, self.index))

--- a/xbox360controller/controller.py
+++ b/xbox360controller/controller.py
@@ -422,7 +422,13 @@ class Xbox360Controller:
     def name(self):
         buf = array("B", [0] * 64)
         ioctl(self._dev_file, JSIOCGNAME(len(buf)), buf)
-        return buf.tostring().decode()
+        try:
+            # Python >=3.2
+            buf_bytes = buf.tobytes()
+        except AttributeError:
+            # Python <3.2
+            buf_bytes = buf.tostring()
+        return buf_bytes.decode()
 
     def info(self):
         print("{0} at index {1}".format(self.name, self.index))


### PR DESCRIPTION
Fixes an `AttributeError` due to a renamed method in the Python standard library.

The `tostring()` method of `array` was renamed to `tobytes()` since Python 3.2. The proposed fix tries to use `tobytes()` and for compatibility falls back to `tostring()` if unavailable.

See documentation of `array.tobytes()`:  
https://docs.python.org/3/library/array.html#array.array.tobytes
> #### `tobytes()`
> Convert the array to an array of machine values and return the bytes representation (the same sequence of bytes that would be written to a file by the [`tofile()`](https://docs.python.org/3/library/array.html#array.array.tofile) method.)  
> _New in version 3.2_: `tostring()` is renamed to [`tobytes()`](https://docs.python.org/3/library/array.html#array.array.tobytes) for clarity.

Fixes #27 

